### PR TITLE
Fix html lang doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,14 @@ Styleguide 2.2
 ##### Global
 
 You can change the global [lang attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/lang).
-To change the lang attribute, add ``"lang": "de"`` into the ``kss-scheibo.json`` as new option.
+To change the lang attribute, add ``"htmllang": "de"`` into the ``kss-scheibo.json`` as new option.
+
+```
+{
+  "custom" : ["HtmlLang"],
+  "htmllang": "de"
+}
+```
 
 #### Hint
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -246,7 +246,12 @@ Styleguide 2.2
 <h4>HTML lang attribute</h4>
 <h5>Global</h5>
 <p>You can change the global <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/lang">lang attribute</a>.
-To change the lang attribute, add <code>&quot;lang&quot;: &quot;de&quot;</code> into the <code>kss-scheibo.json</code> as new option.</p>
+To change the lang attribute, add <code>&quot;htmllang&quot;: &quot;de&quot;</code> into the <code>kss-scheibo.json</code> as new option.</p>
+<pre class="hljs"><code class="language-">{
+  &quot;custom&quot; : [&quot;HtmlLang&quot;],
+  &quot;htmllang&quot;: &quot;de&quot;
+}
+</code></pre>
 <h4>Hint</h4>
 <p>Is the markup a file, the name must be unique.</p>
 <h4>Theme Color</h4>

--- a/kss_styleguide/kss-homepage.md
+++ b/kss_styleguide/kss-homepage.md
@@ -202,7 +202,14 @@ Styleguide 2.2
 ##### Global
 
 You can change the global [lang attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/lang).
-To change the lang attribute, add ``"lang": "de"`` into the ``kss-scheibo.json`` as new option.
+To change the lang attribute, add ``"htmllang": "de"`` into the ``kss-scheibo.json`` as new option.
+
+```
+{
+  "custom" : ["HtmlLang"],
+  "htmllang": "de"
+}
+```
 
 #### Hint
 

--- a/kss_styleguide/scheibo-template/builder.js
+++ b/kss_styleguide/scheibo-template/builder.js
@@ -11,21 +11,24 @@ class KssBuilderScheibo extends KssBuilderHandlebars {
 		this.addOptionDefinitions({
 			requirejs: {
 				group: 'Style guide:',
-				string: true
+				string: true,
+				describe: 'Add RequireJs as global option and in every single fullscreen mode.'
 			}
 		});
 
 		this.addOptionDefinitions({
 			bodyclass: {
 				group: 'Style guide:',
-				string: true
+				string: true,
+				describe: 'Add a global body class and in every single fullscreen mode.'
 			}
 		});
 
 		this.addOptionDefinitions({
 			htmllang: {
 				group: 'Style guide:',
-				string: true
+				string: true,
+				describe: 'Change the global lang attribute.'
 			}
 		});
 	}


### PR DESCRIPTION
There was a wrong description for including the language via lang attribute. This is now fixed.