### PR TITLE
Fix NPM deprecation warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,6 @@
   ],
   "dependencies": {
     "create-html": "^4.1.0",
-    "kss": "^3.0.1"
+    "kss": "git+https://github.com/kss-node/kss-node.git#231900c"
   }
 }


### PR DESCRIPTION
**The KSS package currently throws NPM deprecation warnings.** 
There is a fix in the master branch for this, but it is not yet published on https://www.npmjs.com.

This pull request installs the commit with which highlight.js was updated.

**Fix:** 
https://github.com/kss-node/kss-node/commit/231900cfdf8fc32225b32ba0f58772a3a3dffafe

fixes #8 