### PR TITLE
Draft: Switch NPM KSS package to to fork

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "LSG"
   ],
   "dependencies": {
-    "@franesberger/kss": "^3.1.2",
-    "create-html": "^4.1.0"
+    "create-html": "^4.1.0",
+    "kss": "https://github.com/kss-node/kss-node/tarball/231900c"
   }
 }

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "LSG"
   ],
   "dependencies": {
-    "create-html": "^4.1.0",
-    "kss": "git+https://github.com/kss-node/kss-node.git#231900c"
+    "@franesberger/kss": "^3.1.2",
+    "create-html": "^4.1.0"
   }
 }


### PR DESCRIPTION
Due to problems installing kss-scheibo in my Gitlab CI, I forked kss-node and published it on npmjs.com. 

This should allow the Gitlab CI to run again. 
When the latest version of kss-node is released, we can delete the fork and install the original KSS again.