### PR TITLE
Avoid issues when using kss-scheibo inside CI pipelines

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,6 @@
   ],
   "dependencies": {
     "create-html": "^4.1.0",
-    "kss": "git+https://github.com/kss-node/kss-node.git#231900c"
+    "kss": "https://github.com/kss-node/kss-node/tarball/231900c"
   }
 }


### PR DESCRIPTION
Install the kss tarball version to avoid issues with host key verification in CI pipelines when executing npm install.
(uses https instead of ssh)