### PR TITLE
Improve loading performance

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -272,7 +272,7 @@ To change the lang attribute, add <code>&quot;htmllang&quot;: &quot;de&quot;</co
 <script src="kss-assets/kss-guides.js"></script>
 <script src="kss-assets/search.js"></script>
 <script src="kss-assets/kss-markup.js"></script>
-<script src="kss-assets/prismjs.js"></script>
+<script src="kss-assets/prismjs.js" data-manual></script>
 <script>
   var kssSingleSection = new KssSingleSection();
   var kssFullScreen = new KssFullScreen({

--- a/docs/item-1-1.html
+++ b/docs/item-1-1.html
@@ -218,7 +218,7 @@
 <script src="kss-assets/kss-guides.js"></script>
 <script src="kss-assets/search.js"></script>
 <script src="kss-assets/kss-markup.js"></script>
-<script src="kss-assets/prismjs.js"></script>
+<script src="kss-assets/prismjs.js" data-manual></script>
 <script>
   var kssSingleSection = new KssSingleSection();
   var kssFullScreen = new KssFullScreen({

--- a/docs/item-1-2.html
+++ b/docs/item-1-2.html
@@ -196,7 +196,7 @@
 <script src="kss-assets/kss-guides.js"></script>
 <script src="kss-assets/search.js"></script>
 <script src="kss-assets/kss-markup.js"></script>
-<script src="kss-assets/prismjs.js"></script>
+<script src="kss-assets/prismjs.js" data-manual></script>
 <script>
   var kssSingleSection = new KssSingleSection();
   var kssFullScreen = new KssFullScreen({

--- a/docs/item-1.html
+++ b/docs/item-1.html
@@ -140,7 +140,7 @@
 <script src="kss-assets/kss-guides.js"></script>
 <script src="kss-assets/search.js"></script>
 <script src="kss-assets/kss-markup.js"></script>
-<script src="kss-assets/prismjs.js"></script>
+<script src="kss-assets/prismjs.js" data-manual></script>
 <script>
   var kssSingleSection = new KssSingleSection();
   var kssFullScreen = new KssFullScreen({

--- a/docs/item-2-1.html
+++ b/docs/item-2-1.html
@@ -168,7 +168,7 @@
 
             <details class="kss-markup kss-style">
               <summary>
-                  Markup: <code>templates/02_components/input_label.html</code>
+                  Markup: <code>templates\02_components\input_label.html</code>
               </summary>
               <pre><code class="lang-markup">&lt;div class&#x3D;&quot;form-field [modifier]&quot;&gt;
 	&lt;label class&#x3D;&quot;form-field__label&quot;&gt;Name:&lt;/label&gt;
@@ -194,7 +194,7 @@
 <script src="kss-assets/kss-guides.js"></script>
 <script src="kss-assets/search.js"></script>
 <script src="kss-assets/kss-markup.js"></script>
-<script src="kss-assets/prismjs.js"></script>
+<script src="kss-assets/prismjs.js" data-manual></script>
 <script>
   var kssSingleSection = new KssSingleSection();
   var kssFullScreen = new KssFullScreen({

--- a/docs/item-2-2.html
+++ b/docs/item-2-2.html
@@ -171,7 +171,7 @@
 
             <details class="kss-markup kss-style">
               <summary>
-                  Markup: <code>templates/02_components/form.html</code>
+                  Markup: <code>templates\02_components\form.html</code>
               </summary>
               <pre><code class="lang-markup">&lt;form action&#x3D;&quot;#&quot; method&#x3D;&quot;get&quot; class&#x3D;&quot;form &quot;&gt;
     &lt;div class&#x3D;&quot;form-field form-field--inner&quot;&gt;
@@ -226,7 +226,7 @@
 <script src="kss-assets/kss-guides.js"></script>
 <script src="kss-assets/search.js"></script>
 <script src="kss-assets/kss-markup.js"></script>
-<script src="kss-assets/prismjs.js"></script>
+<script src="kss-assets/prismjs.js" data-manual></script>
 <script>
   var kssSingleSection = new KssSingleSection();
   var kssFullScreen = new KssFullScreen({

--- a/docs/item-2.html
+++ b/docs/item-2.html
@@ -140,7 +140,7 @@
 <script src="kss-assets/kss-guides.js"></script>
 <script src="kss-assets/search.js"></script>
 <script src="kss-assets/kss-markup.js"></script>
-<script src="kss-assets/prismjs.js"></script>
+<script src="kss-assets/prismjs.js" data-manual></script>
 <script>
   var kssSingleSection = new KssSingleSection();
   var kssFullScreen = new KssFullScreen({

--- a/docs/item-colors.html
+++ b/docs/item-colors.html
@@ -184,7 +184,7 @@
 <script src="kss-assets/kss-guides.js"></script>
 <script src="kss-assets/search.js"></script>
 <script src="kss-assets/kss-markup.js"></script>
-<script src="kss-assets/prismjs.js"></script>
+<script src="kss-assets/prismjs.js" data-manual></script>
 <script>
   var kssSingleSection = new KssSingleSection();
   var kssFullScreen = new KssFullScreen({

--- a/docs/kss-assets/kss-markup.js
+++ b/docs/kss-assets/kss-markup.js
@@ -19,6 +19,11 @@
 				self.highlightMarkup(event.currentTarget);
 			});
 		}
+
+		var docsHighlights = document.querySelectorAll('pre.hljs');
+		for (var docsHighlight of docsHighlights) {
+			self.highlightMarkup(docsHighlight);
+		}
 	};
 	// Activation function that takes the ID of the element that will receive
 	// fullscreen focus.
@@ -41,7 +46,7 @@
 	KssMarkup.prototype.highlightMarkup = function(element) {
 		if (!element.classList.contains('prism-highlighted')) {
 			window.Prism.highlightAllUnder(element);
-			element.currentTarget.classList.add('prism-highlighted');
+			element.classList.add('prism-highlighted');
 		}
 	}
 	// Export to DOM global space.

--- a/docs/kss-assets/kss-markup.js
+++ b/docs/kss-assets/kss-markup.js
@@ -12,6 +12,13 @@
 		for (var button of elementList) {
 			button.onclick = self.showGuides.bind(self);
 		}
+
+		var detailMarkupElements = document.querySelectorAll('.' + this.detailsClass);
+		for (var detail of detailMarkupElements) {
+			detail.addEventListener('click', function(event) {
+				self.highlightMarkup(event.currentTarget);
+			});
+		}
 	};
 	// Activation function that takes the ID of the element that will receive
 	// fullscreen focus.
@@ -24,11 +31,19 @@
 				el.removeAttribute('open');
 			} else {
 				el.setAttribute('open', '');
+				this.highlightMarkup(el);
 			}
 		}
 		// Toggle the markup mode.
 		body.classList.toggle(this.bodyClass);
 	};
+
+	KssMarkup.prototype.highlightMarkup = function(element) {
+		if (!element.classList.contains('prism-highlighted')) {
+			window.Prism.highlightAllUnder(element);
+			element.currentTarget.classList.add('prism-highlighted');
+		}
+	}
 	// Export to DOM global space.
 	window.KssMarkup = KssMarkup;
 })(window, document);

--- a/docs/section-1.html
+++ b/docs/section-1.html
@@ -348,7 +348,7 @@
 <script src="kss-assets/kss-guides.js"></script>
 <script src="kss-assets/search.js"></script>
 <script src="kss-assets/kss-markup.js"></script>
-<script src="kss-assets/prismjs.js"></script>
+<script src="kss-assets/prismjs.js" data-manual></script>
 <script>
   var kssSingleSection = new KssSingleSection();
   var kssFullScreen = new KssFullScreen({

--- a/docs/section-2.html
+++ b/docs/section-2.html
@@ -205,7 +205,7 @@
 
             <details class="kss-markup kss-style">
               <summary>
-                  Markup: <code>templates/02_components/input_label.html</code>
+                  Markup: <code>templates\02_components\input_label.html</code>
               </summary>
               <pre><code class="lang-markup">&lt;div class&#x3D;&quot;form-field [modifier]&quot;&gt;
 	&lt;label class&#x3D;&quot;form-field__label&quot;&gt;Name:&lt;/label&gt;
@@ -299,7 +299,7 @@
 
             <details class="kss-markup kss-style">
               <summary>
-                  Markup: <code>templates/02_components/form.html</code>
+                  Markup: <code>templates\02_components\form.html</code>
               </summary>
               <pre><code class="lang-markup">&lt;form action&#x3D;&quot;#&quot; method&#x3D;&quot;get&quot; class&#x3D;&quot;form &quot;&gt;
     &lt;div class&#x3D;&quot;form-field form-field--inner&quot;&gt;
@@ -354,7 +354,7 @@
 <script src="kss-assets/kss-guides.js"></script>
 <script src="kss-assets/search.js"></script>
 <script src="kss-assets/kss-markup.js"></script>
-<script src="kss-assets/prismjs.js"></script>
+<script src="kss-assets/prismjs.js" data-manual></script>
 <script>
   var kssSingleSection = new KssSingleSection();
   var kssFullScreen = new KssFullScreen({

--- a/docs/section-colors.html
+++ b/docs/section-colors.html
@@ -184,7 +184,7 @@
 <script src="kss-assets/kss-guides.js"></script>
 <script src="kss-assets/search.js"></script>
 <script src="kss-assets/kss-markup.js"></script>
-<script src="kss-assets/prismjs.js"></script>
+<script src="kss-assets/prismjs.js" data-manual></script>
 <script>
   var kssSingleSection = new KssSingleSection();
   var kssFullScreen = new KssFullScreen({

--- a/kss_styleguide/scheibo-template/index.hbs
+++ b/kss_styleguide/scheibo-template/index.hbs
@@ -246,7 +246,7 @@
 <script src="kss-assets/kss-guides.js"></script>
 <script src="kss-assets/search.js"></script>
 <script src="kss-assets/kss-markup.js"></script>
-<script src="kss-assets/prismjs.js"></script>
+<script src="kss-assets/prismjs.js" data-manual></script>
 <script>
   var kssSingleSection = new KssSingleSection();
   var kssFullScreen = new KssFullScreen({

--- a/kss_styleguide/scheibo-template/kss-assets/kss-markup.js
+++ b/kss_styleguide/scheibo-template/kss-assets/kss-markup.js
@@ -12,6 +12,13 @@
 		for (var button of elementList) {
 			button.onclick = self.showGuides.bind(self);
 		}
+
+		var detailMarkupElements = document.querySelectorAll('.' + this.detailsClass);
+		for (var detail of detailMarkupElements) {
+			detail.addEventListener('click', function(event) {
+				self.highlightMarkup(event.currentTarget);
+			});
+		}
 	};
 	// Activation function that takes the ID of the element that will receive
 	// fullscreen focus.
@@ -24,11 +31,19 @@
 				el.removeAttribute('open');
 			} else {
 				el.setAttribute('open', '');
+				this.highlightMarkup(el);
 			}
 		}
 		// Toggle the markup mode.
 		body.classList.toggle(this.bodyClass);
 	};
+
+	KssMarkup.prototype.highlightMarkup = function(element) {
+		if (!element.classList.contains('prism-highlighted')) {
+			window.Prism.highlightAllUnder(element);
+			element.currentTarget.classList.add('prism-highlighted');
+		}
+	}
 	// Export to DOM global space.
 	window.KssMarkup = KssMarkup;
 })(window, document);

--- a/kss_styleguide/scheibo-template/kss-assets/kss-markup.js
+++ b/kss_styleguide/scheibo-template/kss-assets/kss-markup.js
@@ -41,7 +41,7 @@
 	KssMarkup.prototype.highlightMarkup = function(element) {
 		if (!element.classList.contains('prism-highlighted')) {
 			window.Prism.highlightAllUnder(element);
-			element.currentTarget.classList.add('prism-highlighted');
+			element.classList.add('prism-highlighted');
 		}
 	}
 	// Export to DOM global space.

--- a/kss_styleguide/scheibo-template/kss-assets/kss-markup.js
+++ b/kss_styleguide/scheibo-template/kss-assets/kss-markup.js
@@ -19,6 +19,11 @@
 				self.highlightMarkup(event.currentTarget);
 			});
 		}
+
+		var docsHighlights = document.querySelectorAll('pre.hljs');
+		for (var docsHighlight of docsHighlights) {
+			self.highlightMarkup(docsHighlight);
+		}
 	};
 	// Activation function that takes the ID of the element that will receive
 	// fullscreen focus.


### PR DESCRIPTION
I recently noticed that large styleguides (or even just styleguide sections) would freeze my entire browser.

I did some performance profiling and found out that the reasoning behind it is the syntax highlighting of [PrismJS](https://prismjs.com) being applied to **all markup sections on load**.

This Pull Request disables automatic highlighting (using the `data-manual` attribute) and adds methods and events to trigger rendering when required.