### PR TITLE
Add generator information to fullpage

### DIFF
--- a/docs/index-1-1_0.html
+++ b/docs/index-1-1_0.html
@@ -4,7 +4,10 @@
 <title>form-input--error - 1-1 - modifier: 0</title>
 <meta charset="utf-8">
 
-<meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
+
+				<meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
+				<meta name="generator" content="kss-node">
+			
 <link rel="stylesheet" href="kss-assets/docs.css">
 
 

--- a/docs/index-1-1_1.html
+++ b/docs/index-1-1_1.html
@@ -4,7 +4,10 @@
 <title>form-input--success - 1-1 - modifier: 1</title>
 <meta charset="utf-8">
 
-<meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
+
+				<meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
+				<meta name="generator" content="kss-node">
+			
 <link rel="stylesheet" href="kss-assets/docs.css">
 
 

--- a/docs/index-1-1_2.html
+++ b/docs/index-1-1_2.html
@@ -4,7 +4,10 @@
 <title>form-input--small - 1-1 - modifier: 2</title>
 <meta charset="utf-8">
 
-<meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
+
+				<meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
+				<meta name="generator" content="kss-node">
+			
 <link rel="stylesheet" href="kss-assets/docs.css">
 
 

--- a/docs/index-1-1_default.html
+++ b/docs/index-1-1_default.html
@@ -4,7 +4,10 @@
 <title>Input - Text - 1-1 - modifier: default</title>
 <meta charset="utf-8">
 
-<meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
+
+				<meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
+				<meta name="generator" content="kss-node">
+			
 <link rel="stylesheet" href="kss-assets/docs.css">
 
 

--- a/docs/index-1-2_0.html
+++ b/docs/index-1-2_0.html
@@ -4,7 +4,10 @@
 <title>btn--cta - 1-2 - modifier: 0</title>
 <meta charset="utf-8">
 
-<meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
+
+				<meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
+				<meta name="generator" content="kss-node">
+			
 <link rel="stylesheet" href="kss-assets/docs.css">
 
 

--- a/docs/index-1-2_1.html
+++ b/docs/index-1-2_1.html
@@ -4,7 +4,10 @@
 <title>btn--disable - 1-2 - modifier: 1</title>
 <meta charset="utf-8">
 
-<meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
+
+				<meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
+				<meta name="generator" content="kss-node">
+			
 <link rel="stylesheet" href="kss-assets/docs.css">
 
 

--- a/docs/index-1-2_default.html
+++ b/docs/index-1-2_default.html
@@ -4,7 +4,10 @@
 <title>Button - Submit - 1-2 - modifier: default</title>
 <meta charset="utf-8">
 
-<meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
+
+				<meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
+				<meta name="generator" content="kss-node">
+			
 <link rel="stylesheet" href="kss-assets/docs.css">
 
 

--- a/docs/index-1-3_default.html
+++ b/docs/index-1-3_default.html
@@ -4,7 +4,10 @@
 <title>Paragraph - 1-3 - modifier: default</title>
 <meta charset="utf-8">
 
-<meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
+
+				<meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
+				<meta name="generator" content="kss-node">
+			
 <link rel="stylesheet" href="kss-assets/docs.css">
 
 

--- a/docs/index-2-1_0.html
+++ b/docs/index-2-1_0.html
@@ -4,7 +4,10 @@
 <title>form-field--inner - 2-1 - modifier: 0</title>
 <meta charset="utf-8">
 
-<meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
+
+				<meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
+				<meta name="generator" content="kss-node">
+			
 <link rel="stylesheet" href="kss-assets/docs.css">
 
 

--- a/docs/index-2-1_default.html
+++ b/docs/index-2-1_default.html
@@ -4,7 +4,10 @@
 <title>Input / Label - 2-1 - modifier: default</title>
 <meta charset="utf-8">
 
-<meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
+
+				<meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
+				<meta name="generator" content="kss-node">
+			
 <link rel="stylesheet" href="kss-assets/docs.css">
 
 

--- a/docs/index-2-2_default.html
+++ b/docs/index-2-2_default.html
@@ -4,7 +4,10 @@
 <title>Form - 2-2 - modifier: default</title>
 <meta charset="utf-8">
 
-<meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
+
+				<meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
+				<meta name="generator" content="kss-node">
+			
 <link rel="stylesheet" href="kss-assets/docs.css">
 
 

--- a/lib/modules/modifierFullscreen.js
+++ b/lib/modules/modifierFullscreen.js
@@ -48,7 +48,10 @@ module.exports = function(Handlebars, options) {
 			script: options.js,
 			scriptModule: options.scriptModule || false,
 			css: options.css,
-			head: '<meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">',
+			head: `
+				<meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
+				<meta name="generator" content="kss-node">
+			`,
 			body: markup + requireJsOutput
 		});
 


### PR DESCRIPTION
It's hard to detect for JavaScript if it is executed inside the prototype environment. 
KSS provides a generator information inside the meta tags, the fullpage does not provide this meta-tag. 
This pull request adds the generator information to the fullpage.